### PR TITLE
Safari-only transform-disable hack & -webkit-mask-composite change to make ticket show on iOS safari

### DIFF
--- a/src/css/bow-border.css
+++ b/src/css/bow-border.css
@@ -18,3 +18,11 @@
   clip-path: polygon(0 0, 100% 0, 100% 50%, 0 50%);
   transform: perspective(100px) rotateX(-8deg);
 }
+
+/* Safari-only hack to disable 3D transform as it breaks parent filters */
+@media not all and (min-resolution:.001dpcm) {
+  .bow-border::before,
+  .bow-border::after {
+    transform: none;
+  }
+}

--- a/src/css/main.css
+++ b/src/css/main.css
@@ -16,7 +16,7 @@
 }
 
 .filter-smooth {
-  filter:url('#filter-smooth');
+  filter: url('#filter-smooth');
 }
 
 .clip-bottom-8 {

--- a/src/css/scooped-corners.css
+++ b/src/css/scooped-corners.css
@@ -5,6 +5,6 @@
     radial-gradient(circle at 100%   0 , var(--stop-list)),
     radial-gradient(circle at   0  100%, var(--stop-list)),
     radial-gradient(circle at 100% 100%, var(--stop-list));
-  -webkit-mask-composite: source-in;
+  -webkit-mask-composite: source-in, xor, xor, xor;
   mask-composite: intersect;
 }


### PR DESCRIPTION
For some crazy reason, on Safari on iOS / iPad, doing a 3D transform on an element will break any filters it's parent elements have. I'm unsure if the issue is on desktop Safari as well, but it probably is as they use the same rendering engine for 3D transforms and filters.

Here's a simplified (but still complex) demo: https://codepen.io/burntcustard/pen/abqQwZa?editors=1100

This PR removes (overrides) the 3D transform on the bow-border class, in Safari only, so instead of this:
![image](https://user-images.githubusercontent.com/462459/173122536-0579392d-8382-47ae-8ba5-300017da8d3e.png)

the ticket will display like this:
![image](https://user-images.githubusercontent.com/462459/173122610-be8b447e-316b-4ac9-a6be-072bb1153e86.png)

The Safari-only CSS selector hack only supports Safari 10.1+ (which is recent enough), I believe on all platforms. It's been taken/simplified from an example here: https://browserstrangeness.bitbucket.io/css_hacks.html#safari
```
@media not all and (min-resolution:.001dpcm) {
  .bow-border::before,
  .bow-border::after {
    transform: none;
  }
}
```
Hopefully in the future Safari will fix it's dodgy filter implementation, so that 3D child elements no longer break parent filters, and then this code (at least the `bow-border` bit) could be removed!